### PR TITLE
bugfix: don't load LyokoAPI.dll

### DIFF
--- a/LyokoPluginLoader/InternalLogger.cs
+++ b/LyokoPluginLoader/InternalLogger.cs
@@ -1,0 +1,57 @@
+using System;
+using System.IO;
+
+namespace LyokoPluginLoader
+{
+    public class InternalLogger
+    {
+        private DirectoryInfo logDir;
+        private FileInfo logFile;
+        public InternalLogger(string logDirPath)
+        {
+            try
+            {
+                EnsureLogDir(logDirPath, out this.logDir);
+                EnsureLogFile(Path.Combine(logDir.FullName,"lyokoPluginLoader.log"));
+
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
+            }
+            
+        }
+
+
+        public void Log(string issue)
+        {
+            File.WriteAllText(logFile.FullName, $"[{DateTime.Now}] {issue}");
+        }
+
+        private bool EnsureLogFile(string logPath)
+        {
+            logFile = new FileInfo(logPath);
+            if (File.Exists(logFile.FullName))
+            {
+                return false;
+            }
+
+            logFile.Create();
+            return true;
+        }
+
+        private bool EnsureLogDir(string path, out DirectoryInfo directory)
+        {
+            if (Directory.Exists(path))
+            {
+                directory = new DirectoryInfo(path);
+                return false;
+            }
+            else
+            {
+                directory =  Directory.CreateDirectory(path);
+                return true;
+            }
+        }
+    }
+}

--- a/LyokoPluginLoader/LyokoPluginLoader.csproj
+++ b/LyokoPluginLoader/LyokoPluginLoader.csproj
@@ -33,7 +33,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="LyokoAPI, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\IFSCLAPI\LyokoAPI\bin\Debug\LyokoAPI.dll</HintPath>
+      <HintPath>..\..\Builds\Lapi\LyokoAPI-V1.1.0.1.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -44,6 +44,7 @@
     <Compile Include="Events\Events.cs" />
     <Compile Include="Events\GameEndEvent.cs" />
     <Compile Include="Events\GameStartEvent.cs" />
+    <Compile Include="InternalLogger.cs" />
     <Compile Include="PluginLoader.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/LyokoPluginLoader/PluginLoader.cs
+++ b/LyokoPluginLoader/PluginLoader.cs
@@ -66,15 +66,18 @@ namespace LyokoPluginLoader
               from file in pluginFiles
               // Load the assembly.
               let asm = Assembly.LoadFile(file)
-              //check for LAPI and lyokopluginloader
+              
+              /*//check for LAPI and lyokopluginloader
+               
               where !asm.FullName.ToLower().Equals("lyokoapi") 
                     || !asm.FullName.ToLower().Equals("LAPI") 
-                    || !asm.FullName.ToLower().Equals((this.GetType().Assembly.FullName.ToLower()))
+                    || !asm.FullName.ToLower().Equals((this.GetType().Assembly.FullName.ToLower()))*/
+              
               // For every type in the assembly that is visible outside of
               // the assembly.
               from type in asm.GetExportedTypes()
               // Where the type implements the interface.
-              where typeof(LyokoAPIPlugin).IsAssignableFrom(type)
+              where type.IsSubclassOf(typeof(LyokoAPIPlugin))
               // Create the instance
               select type
           ).ToList();


### PR DESCRIPTION
But honestly you deserve a broken game if you're putting it in the plugins folder.
Also: more error catching
Also: LyokoPluginLoader creates an internal log file